### PR TITLE
Add mailhog service for hogging mail from appserver

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -30,6 +30,11 @@ services:
     core: default
     config:
       dir: config/solr/7.x/default
+  mailhog:
+    type: mailhog
+    portforward: true
+    hogfrom:
+      - appserver
 tooling:
   xdebug-on:
     service: appserver


### PR DESCRIPTION
Not strictly required for a specific task right now, but seems like good practice to have a mailtrap service for local dev to avoid any accidental sends in future