### PR TITLE
Add global composer library to speed up later downloads

### DIFF
--- a/scripts/appserver_build.sh
+++ b/scripts/appserver_build.sh
@@ -23,6 +23,9 @@ REPOS=(
 # of supporting software or config files.
 NODE_YARN_INSTALLED=/etc/NODE_YARN_INSTALLED
 
+# Add hirak/prestissimo to speed up composer downloads.
+composer global require hirak/prestissimo --no-interaction
+
 # Create export directories for config and data.
 if [ ! -d "/app/exports" ]; then
   echo "Creating export directories"


### PR DESCRIPTION
Makes composer downloads (eg: for first Drupal download) much quicker by having multiple concurrent downloads rather than a slower, sequential process.