### PR TITLE
config changes for xdebug 3

### DIFF
--- a/config/php.ini
+++ b/config/php.ini
@@ -26,8 +26,10 @@ date.timezone = "UTC"
 ;;;;;;;;;;;;;;;;;;;;;;
 
 ; Xdebug
+xdebug.mode=debug
+xdebug.start_with_request=yes
 xdebug.max_nesting_level = 512
-xdebug.remote_autostart = 1
+xdebug.client_host="${LANDO_HOST_IP}"
 
 ; Globals
 expose_php = on


### PR DESCRIPTION
With the latest release of xdebug (version 3) it was no longer possible to debug using PHPStorm with our old configuration.
Xdebug config has been amended accordingly in php.ini - note that xdebug will default to port 9003 now, so you will need to change your PHPStorm config if you're not already using that port.